### PR TITLE
Set connection name; get rid of resize

### DIFF
--- a/config/world.go
+++ b/config/world.go
@@ -12,7 +12,7 @@ type World struct {
 	Name string
 
 	// A free-form display name for the world.
-	DisplayName string
+	DisplayName string `yaml:"display_name" toml:"display_name"`
 
 	// The server to which this world belongs.
 	Server string

--- a/ui/keybindings.go
+++ b/ui/keybindings.go
@@ -95,8 +95,16 @@ func keybindings(g *gotui.Gui) error {
 		return err
 	}
 	if err := g.SetKeybinding("", gotui.KeyCtrlL, gotui.ModNone, func(g *gotui.Gui, v *gotui.View) error {
-		g.Update(func(g *gotui.Gui) error { return nil })
 		log.Debugf("redrawing")
+		v, err := g.View(currView.viewName)
+		if err != nil {
+			return err
+		}
+		v.Clear()
+		fmt.Fprint(v, currView.buffer.String())
+		g.Update(func(gg *gotui.Gui) error {
+			return currView.updateRecvOrigin(currViewIndex, gg)
+		})
 		return nil
 	}); err != nil {
 		return err


### PR DESCRIPTION
Fixes #34
Fixes #6

The scroll-from-bottom hack was not cutting it. Will take some work upstream on gotui. For now, we can start at top.