### PR TITLE
Update logging

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -18,12 +18,28 @@
   version = "v1.0.8"
 
 [[projects]]
+  branch = "master"
+  digest = "1:f14d1b50e0075fb00177f12a96dd7addf93d1e2883c25befd17285b779549795"
+  name = "github.com/gopherjs/gopherjs"
+  packages = ["js"]
+  pruneopts = "UT"
+  revision = "d547d1d9531ed93dbdebcbff7f83e7c876a1e0ee"
+
+[[projects]]
   digest = "1:870d441fe217b8e689d7949fef6e43efbc787e50f200cb1e70dbca9204a1d6be"
   name = "github.com/inconshreveable/mousetrap"
   packages = ["."]
   pruneopts = "UT"
   revision = "76626ae9c91c4f2a10f34cad8ce83ea42c93bb75"
   version = "v1.0"
+
+[[projects]]
+  digest = "1:4b63210654b1f2b664f74ec434a1bb1cb442b3d75742cc064a10808d1cca6361"
+  name = "github.com/jtolds/gls"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "b4936e06046bbecbb94cae9c18127ebe510a2cb9"
+  version = "v4.20"
 
 [[projects]]
   branch = "master"
@@ -38,12 +54,9 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:3065ab0c3dbf6827a1c406a94f0a89f8c1e9af9fe04b457fc38fee33957f311e"
+  digest = "1:a330103bc9731260ee9fa14764e9e3fce46e02de19d6aca3eeba1d425badfbf0"
   name = "github.com/juju/loggo"
-  packages = [
-    ".",
-    "loggocolor",
-  ]
+  packages = ["."]
   pruneopts = "UT"
   revision = "584905176618da46b895b176c721b02c476b6993"
 
@@ -57,11 +70,27 @@
 
 [[projects]]
   branch = "master"
+  digest = "1:3aa8059ec1943b61c1ef925b76358f9eee352c790360d3bb8cee6fc23bba5053"
+  name = "github.com/makyo/ansigo"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "6233c8d7c2e337a84511d3b26378539045903698"
+
+[[projects]]
+  branch = "master"
   digest = "1:5103f4ffd7a9287d1dd35289e8f1e16b1d847000cccae7abd7368dedfbb1950a"
   name = "github.com/makyo/gotui"
   packages = ["."]
   pruneopts = "UT"
   revision = "898f0801ec62b9f2923acc8ee35ba3b4d7e143fd"
+
+[[projects]]
+  branch = "master"
+  digest = "1:ff89e498f29a3dfe8d25f72c1cce259773e8b4de7e1f089ca94859352449aebd"
+  name = "github.com/makyo/loggocolor"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "b55f5f3893e7921b9180a48fa3fd59975abaec38"
 
 [[projects]]
   digest = "1:94892f041853bd09edfbafae5b8e0b98d6f32c23df57a4d6cd0ccbdfce3c81f0"
@@ -120,6 +149,30 @@
   version = "v1.5.2"
 
 [[projects]]
+  digest = "1:cc1c574c9cb5e99b123888c12b828e2d19224ab6c2244bda34647f230bf33243"
+  name = "github.com/smartystreets/assertions"
+  packages = [
+    ".",
+    "internal/go-render/render",
+    "internal/oglematchers",
+  ]
+  pruneopts = "UT"
+  revision = "7678a5452ebea5b7090a6b163f844c133f523da2"
+  version = "1.8.3"
+
+[[projects]]
+  digest = "1:a3e081e593ee8e3b0a9af6a5dcac964c67a40c4f2034b5345b2ad78d05920728"
+  name = "github.com/smartystreets/goconvey"
+  packages = [
+    "convey",
+    "convey/gotest",
+    "convey/reporting",
+  ]
+  pruneopts = "UT"
+  revision = "9e8dc3f972df6c8fcc0375ef492c24d0bb204857"
+  version = "1.6.3"
+
+[[projects]]
   digest = "1:e01b05ba901239c783dfe56450bcde607fc858908529868259c9a8765dc176d0"
   name = "github.com/spf13/cobra"
   packages = [
@@ -159,10 +212,12 @@
   analyzer-version = 1
   input-imports = [
     "github.com/juju/loggo",
-    "github.com/juju/loggo/loggocolor",
+    "github.com/makyo/ansigo",
     "github.com/makyo/gotui",
+    "github.com/makyo/loggocolor",
     "github.com/makyo/snuffler",
     "github.com/mitchellh/go-homedir",
+    "github.com/smartystreets/goconvey/convey",
     "github.com/spf13/cobra",
     "github.com/spf13/cobra/doc",
   ]

--- a/cmd/st/main.go
+++ b/cmd/st/main.go
@@ -9,9 +9,23 @@
 package main
 
 import (
+	"os"
+	"path/filepath"
+
+	"github.com/juju/loggo"
+
 	"github.com/makyo/stimmtausch/cmd"
+	"github.com/makyo/stimmtausch/config"
 )
 
 func main() {
+	config.InitDirs()
+	f, err := os.Create(filepath.Join(config.LogDir, "stimmtausch.log"))
+	if err != nil {
+		panic(err)
+	}
+	defer f.Close()
+	loggo.ReplaceDefaultWriter(loggo.NewSimpleWriter(f, loggo.DefaultFormatter))
+
 	cmd.Execute()
 }

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -11,7 +11,6 @@ import (
 	"os"
 
 	"github.com/juju/loggo"
-	"github.com/juju/loggo/loggocolor"
 	"github.com/spf13/cobra"
 	"github.com/spf13/cobra/doc"
 )
@@ -25,8 +24,6 @@ func initFlags(cmd *cobra.Command) {
 
 // initConfig initializes the configuration used within the session.
 func initLogging(logLevel string) {
-	// TODO log to file
-	loggo.ReplaceDefaultWriter(loggocolor.NewWriter(os.Stderr))
 	loggo.ConfigureLoggers(fmt.Sprintf("<root>=%s", logLevel))
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -156,10 +156,7 @@ func (c *Config) FinalizeAndValidate() []error {
 // sources.
 func Load() (*Config, error) {
 	log.Debugf("loading configuration")
-	err := initEnv()
-	if err != nil {
-		return nil, err
-	}
+	InitDirs()
 
 	var wrap wrapper
 	snoot := snuffler.New(&wrap)

--- a/config/util.go
+++ b/config/util.go
@@ -7,6 +7,7 @@
 package config
 
 import (
+	"fmt"
 	"path/filepath"
 
 	homedir "github.com/mitchellh/go-homedir"
@@ -18,15 +19,16 @@ var (
 	ConfigDir    string
 	WorkingDir   string
 	LogDir       string
-	Environment  string
 )
 
-// initDirs initializes the directories used by Stimmtausch.
-func initEnv() error {
+// InitDirs initializes the directories used by Stimmtausch.
+func InitDirs() {
+	if HomeDir != "" && ConfigDir != "" && WorkingDir != "" && LogDir != "" {
+		return
+	}
 	HomeDir, err := homedir.Dir()
 	if err != nil {
-		log.Criticalf("could not find homedir: %v", err)
-		return err
+		panic(fmt.Sprintf("could not find home dir: %v", err))
 	}
 	ConfigDir = filepath.Join(HomeDir, ".config", "stimmtausch")
 	WorkingDir = filepath.Join(HomeDir, ".local", "share", "stimmtausch")
@@ -47,5 +49,4 @@ func initEnv() error {
 		"_conf/local/*.toml",
 		"_conf/local/*.json",
 	}
-	return nil
 }


### PR DESCRIPTION
Fixes #28

This syslogs to a file in `LogDir` and logs color to the console via an update to loggocolor. Tangentially fixed #45 and added godocs