### PR TITLE
Add `more` functionality

### DIFF
--- a/_conf/global/conf.d/client.yaml
+++ b/_conf/global/conf.d/client.yaml
@@ -66,14 +66,14 @@ stimmtausch:
           # Focused world
           active: "bold+white"
           # Focused world, scrolled up with new activity
-          active_more: "bold+green"
+          active_more: "bold+underline+white"
           # Non-focused world
           inactive: "steelblue"
           # Non-focused world with new activity
-          inactive_more: "steelblue+bold"
+          inactive_more: "steelblue+underline"
           # Disconnected world (non-focused)
           disconnected: "mediumvioletred"
           # Disconnected world with new activity
-          disconnected_more: "mediumvioletred+bold"
+          disconnected_more: "mediumvioletred+underline"
           # Disconnected world (non-focused) with unread lines
           disconnected_active: "deeppink3"

--- a/ui/keybindings.go
+++ b/ui/keybindings.go
@@ -133,7 +133,10 @@ func (t *tui) scrollUp(g *gotui.Gui, v *gotui.View) error {
 	if result < 0 {
 		result = 0
 	}
+	t.currView.hasMore = true
+	t.currView.more = lines - (result + maxY)
 	log.Debugf("got %d lines, setting origin to 0,%d: %v", lines, result, v.SetOrigin(0, result))
+	t.updateSendTitle()
 	return nil
 }
 
@@ -151,11 +154,17 @@ func (t *tui) scrollDown(g *gotui.Gui, v *gotui.View) error {
 	if result < lines {
 		if result+maxY > lines {
 			result = result - (result + maxY - lines) - 1
+			t.currView.hasMore = false
 		}
 		if result != y {
+			t.currView.more = lines - (result + maxY)
 			log.Debugf("got %d lines, setting origin to 0,%d: %v", lines, result, v.SetOrigin(0, result))
 		}
+	} else {
+		t.currView.hasMore = false
+		t.currView.more = 0
 	}
+	t.updateSendTitle()
 	return nil
 }
 
@@ -173,7 +182,7 @@ func (t *tui) redraw(g *gotui.Gui, v *gotui.View) error {
 	// https://github.com/makyo/stimmtausch/issues/46
 	v.SetOrigin(x, y)
 	g.Update(func(gg *gotui.Gui) error {
-		return t.currView.updateRecvOrigin(t.currViewIndex, gg)
+		return t.currView.updateRecvOrigin(t.currViewIndex, gg, t)
 	})
 	return nil
 }


### PR DESCRIPTION
Now, when scrolled up, new lines don't cause the window to scroll back out of range, but instead add to a counter on the title bar. This also works for windows you're not currently viewing. For a future branch, we may want a marker of last seen position like tf.

![2020-05-16-151824_1920x1080_scrot](https://user-images.githubusercontent.com/303761/82132342-91c7d280-9793-11ea-9eb5-872cf0dfdaf1.png)
