### PR TITLE
Allow triggers to be world-specific

### DIFF
--- a/config/trigger.go
+++ b/config/trigger.go
@@ -21,6 +21,9 @@ type Trigger struct {
 	// The type of trigger: hilite, gag, script, macro.
 	Type string
 
+	// The world to which this trigger applies (if blank, applies to all).
+	World string
+
 	// A regexp to match against.
 	Match string
 
@@ -84,11 +87,16 @@ func (t Trigger) Compile() (*Trigger, error) {
 
 // Run takes the provided byte-slice from the world and, if it matches, runs
 // the action specified in the trigger based on the type (hilite, gag, script
-// macro). It returns the (potentially modified) input, whether or not the
-// trigger matched, and any errors it encountered along the way.
-func (t *Trigger) Run(input string, cfg *Config) (bool, string, []error) {
+// macro) if the world matches the one specified in the trigger (if none is
+// specified, it matches all worlds). It returns the (potentially modified)
+// input, whether or not the trigger matched, and any errors it encountered
+// along the way.
+func (t *Trigger) Run(world, input string, cfg *Config) (bool, string, []error) {
 	log.Tracef("running trigger %s", t.Name)
 	applies := false
+	if t.World != "" && t.World != world {
+		return false, input, []error{}
+	}
 	var errs []error
 	for _, re := range t.reList {
 		if matches := re.FindAllStringSubmatchIndex(input, -1); len(matches) != 0 {

--- a/connection/connection.go
+++ b/connection/connection.go
@@ -258,7 +258,7 @@ func (c *Connection) readToFile() {
 		var applies, gag, logAnyway bool
 		orig := line
 		for _, trigger := range c.config.CompiledTriggers {
-			applies, line, triggerErrs = trigger.Run(line, c.config)
+			applies, line, triggerErrs = trigger.Run(c.world.Name, line, c.config)
 			if len(triggerErrs) != 0 {
 				errs = append(errs, triggerErrs...)
 			}

--- a/docs/docs/config.md
+++ b/docs/docs/config.md
@@ -172,6 +172,10 @@ Values
 
       Example: `type: hilite`
 
+    * `world` (*string* optional; the name (not display name) of a world) - the world to which this trigger should apply. If none is specified, it will apply to every world.
+
+      Example: `world: fm_foxface`
+
     * `match` (*string* either `match` or `matches` or both are required) - the [regular expression](https://golang.org/pkg/regexp/) to match in the line.
 
       Example: `match: "[Ff]oxface"`
@@ -204,8 +208,9 @@ stimmtausch:
           type: hilite
           matches: ["[Ff]oxface", "[Rr]udderbutt"]
           attributes: "bold+green"
-        - name: "I hate this guy..."
+        - name: "I hate this guy, but he's only on FM..."
           type: gag
+          world: furrymuck
           match: "(?i)bad-wolf"
         # More triggers...
 ```


### PR DESCRIPTION
This adds a `world` key in the trigger object. If specified, it will only apply that trigger to the specified world. If not, it applies it to every world.